### PR TITLE
Pull $release from the $release_overwrite variable

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -51,7 +51,7 @@ fi
 if [ -f "$source/$release_overwrite" ]; then
   release=$(cat $source/$release_overwrite)
 elif [ -n "$release_overwrite" ]; then
-  release=$release
+  release=$release_overwrite
 fi
 
 if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then


### PR DESCRIPTION
This was breaking when I specified `.params.release` as a string (it works just fine in my other pipelines where we specify a path). This fixes it