### PR TITLE
Change version check to error if empty

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -59,7 +59,7 @@ if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then
   chart_full="$source/$chart"
   version=""
 else
-  if [ -n "$version" ]; then
+  if [ -z "$version" ]; then
     echo "invalid payload (missing version if chart is from repository."
     exit 1
   fi


### PR DESCRIPTION
Fixes: https://github.com/Typositoire/concourse-helm3-resource/issues/9

This always requires a version to be set now. Or we can remove this check, as the version is only added if set further down in the code