### PR TITLE
fix: Repo can be specified without shell error

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -105,7 +105,7 @@ setup_repos() {
 
   local IFS=$'\n'
 
-  if [ $plugins ]
+  if [ "$plugins" ]
   then
     for pl in $plugins; do
       plurl=$(echo $pl | jq -cr '.url')
@@ -122,7 +122,7 @@ setup_repos() {
     done
   fi
 
-  if [ $repos ]
+  if [ "$repos" ]
   then
     for r in $repos; do
       name=$(echo $r | jq -r '.name')


### PR DESCRIPTION
If there is a repo specified in the source, the step errors like this:

 > /opt/resource/common.sh: line 125: [: {"name":"incubator","url":"http://storage.googleapis.com/kubernetes-charts-incubator"}: unary operator expected

config:
```
  - name: helm3-deploy
    type: helm3
    source:
      repos:
        - name: incubator
          url: http://storage.googleapis.com/kubernetes-charts-incubator
```

Quoting the test value in Bash should solve this. Maybe a test like `[ -n "$repos" ]` would be even better?