### PR TITLE
Update kubectl & helm to latest stable versions; fix helm dry-run issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine/helm:3.0.2
+FROM alpine/helm:3.2.0
 LABEL maintainer "Yann David (@Typositoire) <davidyann88@gmail>"
 
 RUN apk add --update --upgrade --no-cache jq bash curl git
 
-ARG KUBERNETES_VERSION=1.16.3
+ARG KUBERNETES_VERSION=1.18.2
 RUN curl -sL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl; \
   chmod +x /usr/local/bin/kubectl
 

--- a/assets/out
+++ b/assets/out
@@ -223,6 +223,6 @@ else
     echo "$result" | jq -s add  >&3
   else
     echo "Debug was set to ${debug}; no release was performed. | tee $logfile"
-    echo '{"version": {"revision": "N/A", "release": "N/A"}}'
+    echo '{"version": {"revision": "N/A", "release": "N/A"}}' >&3
   fi
 fi

--- a/assets/out
+++ b/assets/out
@@ -98,7 +98,7 @@ current_deployed() {
 }
 
 helm_upgrade() {
-   if [ "$release" == "" ]; then
+  if [ "$release" == "" ]; then
     upgrade_args=("install" $chart_full "--namespace=$namespace")
   else
     upgrade_args=("upgrade" "--install" "$release" $chart_full "--namespace=$namespace")
@@ -213,10 +213,15 @@ elif [ "$test" = true ]; then
 else
   echo "Installing $release"
   helm_upgrade
-  deployed=$(current_deployed "$release")
-  revision=$(echo $deployed | awk '{ print $1 }')
-  chart=$(echo $deployed | awk '{ print $8 }')
-  echo "Deployed revision $revision of $release"
-  result="$(jq -n "{version:{release:\"$release\", revision:\"$revision\"}, metadata: [{name: \"release\", value: \"$release\"},{name: \"revision\", value: \"$revision\"},{name: \"chart\", value: \"$chart\"}]}")"
-  echo "$result" | jq -s add  >&3
+
+  if [ "$debug" != "true" ]; then
+    deployed=$(current_deployed "$release")
+    revision=$(echo $deployed | awk '{ print $1 }')
+    chart=$(echo $deployed | awk '{ print $8 }')
+    echo "Deployed revision $revision of $release"
+    result="$(jq -n "{version:{release:\"$release\", revision:\"$revision\"}, metadata: [{name: \"release\", value: \"$release\"},{name: \"revision\", value: \"$revision\"},{name: \"chart\", value: \"$chart\"}]}")"
+    echo "$result" | jq -s add  >&3
+  else
+    echo "Debug was set to ${debug}; no release was performed. | tee $logfile"
+  fi
 fi

--- a/assets/out
+++ b/assets/out
@@ -223,5 +223,6 @@ else
     echo "$result" | jq -s add  >&3
   else
     echo "Debug was set to ${debug}; no release was performed. | tee $logfile"
+    echo '{"version": {"revision": "N/A", "release": "N/A"}}'
   fi
 fi


### PR DESCRIPTION
This upgrades helm to v3.2.0 and kubectl to 1.18.2

It also resolves an issue with using the resource when debug: true

Previously I would get an error that failed the whole pipeline:

```
NOTES:
1. The maintenance page should be accessible at the below pages:

<SNIP>
Error: release: not found
```

After adding my changes

```
NOTES:
1. The maintenance page should be accessible at the below pages:

<SNIP>
Debug was set to true; no release was performed. | tee /tmp/log`
```

An except of the concourse pipeline I tested with

```yaml
jobs:
- name: deploy-maintenance-helm
  plan:
  - get: maintenance-page
  - put: maintenance-page-helm
    params:
      chart: maintenance-page/helm/maintenance
      values: maintenance-page/helm/maintenance/my-values.yaml
      debug: true
      release: maintenance-mynamespace
...
resources:
- name: maintenance-page
  type: git
  check_every: 5m
  source:
    <snip>
- name: maintenance-page-helm
  type: helm
  source:
    cluster_url: <cluster_url>
    insecure_cluster: true
    token: ((k8s_token))
    namespace: 'mynamespace'
    helm_history_max: 5
```

I believe the error is due to this being executed and helm erroring out as there is no release to retrieve if only a dry-run / debug command has been run.

```bash
current_deployed() {
  local release="$1"
  $helm_bin history --max 20 $release --namespace $namespace | grep -i "DEPLOYED"
}
```