### PR TITLE
Adding the create_namespace param

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Deploy an helm chart
 
 * `chart`: *Required.* Either the file containing the helm chart to deploy (ends with .tgz), the path to a local directory containing the chart or the name of the chart from a repo (e.g. `stable/mysql`).
 * `namespace`: *Optional.* Either a file containing the name of the namespace or the name of the namespace. (Default: taken from source configuration).
+* `create_namespace`: *Optional.* Create the namespace if it doesn't exist (Default: false).
 * `release`: *Optional.* Either a file containing the name of the release or the name of the release. (Default: taken from source configuration).
 * `values`: *Optional.* File containing the values.yaml for the deployment. Supports setting multiple value files using an array.
 * `override_values`: *Optional.* Array of values that can override those defined in values.yaml. Each entry in

--- a/assets/out
+++ b/assets/out
@@ -22,6 +22,7 @@ release=$(jq -r '.source.release // ""' < $payload)
 chart=$(jq -r '.params.chart // ""' < $payload)
 version=$(jq -r '.params.version // ""' < $payload)
 namespace_overwrite=$(jq -r '.params.namespace // ""' < $payload)
+create_namespace=$(jq -r '.params.create_namespace // "false"' < $payload)
 atomic=$(jq -r '.params.atomic // "false"' < $payload)
 release_overwrite=$(jq -r '.params.release // ""' < $payload)
 values=$(jq -r '.params.values // "" | if type == "array" then .[] else . end' < $payload)
@@ -110,6 +111,10 @@ helm_upgrade() {
   overridden_args=()
   scrubbed_overridden_args=()
   set_overridden_values
+
+  if [ "$create_namespace" == "true" ]; then
+    upgrade_args+=("--create-namespace")
+  fi
 
   if [ "$check_is_ready" == "true" ]; then
     upgrade_args+=("--wait")


### PR DESCRIPTION
As far as I can tell - there is no way to do this currently.  In helm 3 the namespace is expected to exist or else you must pass this flag