### PR TITLE
remove syntax error causing check json return to always be empty

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -26,7 +26,7 @@ if [ -z "$release" ]; then
   release="$current_release"
 fi
 
-if [ "$release"]
+if [ "$release" ]
   then
   if [ $current_rev -eq "0" ]; then
     last_rev=$($helm_bin history --max 20 $release --namespace $namespace -o json | jq -r '.[-1].revision')


### PR DESCRIPTION
syntax error , missing whitespace in if declaration, causing check returns to always be

echo '[]' | jq . >&3

--

let me know if I should bump version or if you'd rather do it.