### PR TITLE
fix stable repo url

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -144,7 +144,7 @@ setup_repos() {
     $helm_bin repo update
   fi
 
-  $helm_bin repo add stable https://kubernetes-charts.storage.googleapis.com
+  $helm_bin repo add stable https://charts.helm.sh/stable
   $helm_bin repo update
 }
 


### PR DESCRIPTION
The old location of the stable charts repo is deprecated and does no longer work, see https://helm.sh/blog/new-location-stable-incubator-charts/