### PR TITLE
update stable_repo source parameter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ resource_types:
 * `helm_history_max`: *Optional.* Limits the maximum number of revisions. (Default: 0 = no limit)
 * `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with properties `name`, `url` (required) username and password (optional).
 * `plugins`: *Optional.* Array of Helm plugins to install, each defined as an object with properties `url` (required), `version` (optional).
-* `stable_repo`: *Optional* Override default Helm stable repo <https://kubernetes-charts.storage.googleapis.com>. Useful if running helm deploys without internet access.
+* `stable_repo`: *Optional* Override default Helm stable repo <https://charts.helm.sh/stable>. Useful if running helm deploys without internet access.
 * `tracing_enabled`: *Optional.* Enable extremely verbose tracing for this resource. Useful when developing the resource itself. May allow secrets to be displayed. (Default: false)
 * `helm_setup_purge_all`: *Optional.* Delete and purge every helm release. Use with extreme caution. (Default: false)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ resource_types:
 * `helm_history_max`: *Optional.* Limits the maximum number of revisions. (Default: 0 = no limit)
 * `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with properties `name`, `url` (required) username and password (optional).
 * `plugins`: *Optional.* Array of Helm plugins to install, each defined as an object with properties `url` (required), `version` (optional).
-* `stable_repo`: *Optional* Override default Helm stable repo <https://charts.helm.sh/stable>. Useful if running helm deploys without internet access.
+* `stable_repo`: *Optional* A `false` value will disable using a default Helm stable repo. Any other value will be used to Override default Helm stable repo URL <https://charts.helm.sh/stable>. Useful if running helm deploys without internet access.
 * `tracing_enabled`: *Optional.* Enable extremely verbose tracing for this resource. Useful when developing the resource itself. May allow secrets to be displayed. (Default: false)
 * `helm_setup_purge_all`: *Optional.* Delete and purge every helm release. Use with extreme caution. (Default: false)
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -144,9 +144,12 @@ setup_repos() {
 
     $helm_bin repo update
   fi
+ 
 
-  $helm_bin repo add stable $stable_repo
-  $helm_bin repo update
+  if [ ! "$stable_repo" == "false" ]; then
+    $helm_bin repo add stable $stable_repo
+    $helm_bin repo update
+  fi
 }
 
 setup_resource() {

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -105,6 +105,7 @@ wait_for_service_up() {
 setup_repos() {
   repos=$(jq -c '(try .source.repos[] catch [][])' < $1)
   plugins=$(jq -c '(try .source.plugins[] catch [][])' < $1)
+  stable_repo=$(jq -r '.source.stable_repo // "https://charts.helm.sh/stable"' <$1 )
 
   local IFS=$'\n'
 
@@ -144,7 +145,7 @@ setup_repos() {
     $helm_bin repo update
   fi
 
-  $helm_bin repo add stable https://charts.helm.sh/stable
+  $helm_bin repo add stable $stable_repo
   $helm_bin repo update
 }
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -144,7 +144,6 @@ setup_repos() {
 
     $helm_bin repo update
   fi
- 
 
   if [ ! "$stable_repo" == "false" ]; then
     $helm_bin repo add stable $stable_repo

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -105,7 +105,7 @@ wait_for_service_up() {
 setup_repos() {
   repos=$(jq -c '(try .source.repos[] catch [][])' < $1)
   plugins=$(jq -c '(try .source.plugins[] catch [][])' < $1)
-  stable_repo=$(jq -r '.source.stable_repo // "https://charts.helm.sh/stable"' <$1 )
+  stable_repo=$(jq -r '.source.stable_repo // "https://charts.helm.sh/stable"' < $1 )
 
   local IFS=$'\n'
 


### PR DESCRIPTION
suggested possible improvement:

* `stable_repo`: *Optional* Override default Helm stable repo <https://charts.helm.sh/stable>. Useful if running helm deploys without internet access, or you know, if the default just friggin disappears one day.

submitted in humble appreciation of PR 44 , which did save me quite the headache today.