### PR TITLE
remove wrong if to make default stable repo work

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -145,10 +145,8 @@ setup_repos() {
     $helm_bin repo update
   fi
 
-  if [ ! "$stable_repo" == "false" ]; then
-    $helm_bin repo add stable $stable_repo
-    $helm_bin repo update
-  fi
+  $helm_bin repo add stable $stable_repo
+  $helm_bin repo update
 }
 
 setup_resource() {


### PR DESCRIPTION
Removing a wrong if statement to make default stable repo work.
It does not make to check if `stable_repo` is `false` coz in any case a `stable` repo should be added with a default value or injected one.