### PR TITLE
Migration from Concourse to Github Actions

### DIFF
--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,6 +1,7 @@
 name: Create and publish a Docker image
 
 on:
+  pull_request:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,0 +1,40 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:  # Enable manual triggering
+    inputs:
+      tag:
+        description: 'Docker image tag'
+        required: false
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Docker image tag
+        id: set_docker_tag
+        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> $GITHUB_OUTPUT
+        continue-on-error: true
+        shell: bash
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/typositoire/concourse-helm3-resource:${{ steps.set_docker_tag.outputs.tag }}
+            ghcr.io/typositoire/concourse-helm3-resource:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Create and publish a Docker image
 
 on:
+  pull_request:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Create and publish a Docker image
 
 on:
-  pull_request:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Create and publish a Docker image
 
 on:
-  pull_request:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -35,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
+          push: true
           tags: |
             ghcr.io/typositoire/concourse-helm3-resource:${{ steps.set_docker_tag.outputs.tag }}
             ghcr.io/typositoire/concourse-helm3-resource:latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,74 @@
+name: Check PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files_ignore: |
+            README.md
+            ci/**
+            .github/**
+      - name: List all changed files
+        id: list_changed_files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES_COUNT: ${{ steps.changed-files.outputs.all_modified_files_count }}
+        run: |
+          echo "${ALL_MODIFIED_FILES_COUNT} files"
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
+
+          echo "msg=Version bump not required." >> $GITHUB_OUTPUT
+      - name: auto_pass
+        if: steps.changed-files.outputs.all_modified_files_count == '0'
+        id: check_if_only_ignored
+        run: |
+          exit 0
+        
+      - name: Get version from file
+        if: steps.changed-files.outputs.all_modified_files_count != '0'
+        id: get_version
+        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: 'Get Previous tag'
+        if: steps.changed-files.outputs.all_modified_files_count != '0'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1.4.0"
+
+      - name: Checking for version bump
+        if: steps.changed-files.outputs.all_modified_files_count != '0'
+        id: check_vbump
+        run: |
+          LAST_TAG="${{ steps.previoustag.outputs.tag }}"
+          NEW_TAG="v${{ steps.get_version.outputs.version }}"
+          RESULT=$(ci/assets/checksemver.sh ${NEW_TAG} ${LAST_TAG})
+          if [ "${RESULT}" == "1" ]; then
+            echo "msg=Version bump found." >> $GITHUB_OUTPUT
+            exit 0
+          elif [ "${RESULT}" == "0" ]; then
+            echo "msg=Version bump did not happen. ${LAST_TAG} is the same as ${NEW_TAG}" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "msg=Version bump did not happen. ${LAST_TAG} is higher than ${NEW_TAG}" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+      - uses: mshick/add-pr-comment@v2.8.2
+        if: always()
+        with:
+          message: |
+            ${{ steps.list_changed_files.outputs.msg || steps.check_vbump.outputs.msg }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:  # Enable manual triggering
     inputs:
       tag:
-        description: 'Version to tag'
+        description: 'Version to tag (without the prefix v)'
         required: false
 jobs:
   tag:
@@ -21,5 +21,5 @@ jobs:
       - name: Create tag
         id: create_tag
         run: |
-          git tag -a ${{ steps.get_version.outputs.version }} -m "Tagging version ${{ steps.get_version.outputs.version }}"
-          git push origin ${{ steps.get_version.outputs.version }}
+          git tag -a v${{ github.event.inputs.tag || steps.get_version.outputs.version }} -m "Tagging version v${{ github.event.inputs.tag || steps.get_version.outputs.version }}"
+          git push origin v${{ github.event.inputs.tag || steps.get_version.outputs.version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,28 @@
+name: Tag Main
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:  # Enable manual triggering
+    inputs:
+      tag:
+        description: 'Version to tag'
+        required: false
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get version from file
+        id: get_version
+        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+      - name: Create tag
+        id: create_tag
+        run: |
+          git status
+          echo ${{ steps.get_version.outputs.version }}
+          # git tag -a ${{ steps.get_version.outputs.version }} -m "Tagging version ${{ steps.get_version.outputs.version }}"
+          # git push origin ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,7 +1,6 @@
 name: Tag Main
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -22,7 +21,5 @@ jobs:
       - name: Create tag
         id: create_tag
         run: |
-          git status
-          echo ${{ steps.get_version.outputs.version }}
-          # git tag -a ${{ steps.get_version.outputs.version }} -m "Tagging version ${{ steps.get_version.outputs.version }}"
-          # git push origin ${{ steps.get_version.outputs.version }}
+          git tag -a ${{ steps.get_version.outputs.version }} -m "Tagging version ${{ steps.get_version.outputs.version }}"
+          git push origin ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
@Tang8330 Let's check if you can FORCE MERGE for a while in case the new check is misbehaving but you should be able to update it now that it's GitHub completely.

I've done the best I can to test this, next few PR/Release might be bumpy but we can fix that you know where to reach me. If the need arise, I can easily remove tags from GHCR (not my first rodeo with new Workflow xD)

- New Check is now required
- Concourse check has been disabled and pipeline is paused
- Another PR will cleanup the `ci/` folder 

TL;DR my current OVH instance is getting hit by inflation, going from 40$ / Month to 120$ + / month. As a result I'm moving all the checks and build to be GitHub Action. While this seems counter productive to use GitHub Action for a Concourse resource, this should help maintaining the resource for @Tang8330 as giving access to my personal Concourse would have been less than optimal.

Couple of improvements:

- If changes made to only `README.md`, `ci/**` or `.github/**`, the check should pass without running anything.
- All the workflows should be able to run by hand with some inputs once merged in main.