### PR TITLE
Only pushes to VERSION

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - VERSION
   workflow_dispatch:  # Enable manual triggering
     inputs:
       tag:


### PR DESCRIPTION
Current workflow triggers a tag for EVERY push. Definitely not what we want.